### PR TITLE
Refactor: Adjusted Rate Limiting and Throttle Class Definitions

### DIFF
--- a/accounts/throttles.py
+++ b/accounts/throttles.py
@@ -4,9 +4,7 @@ from rest_framework.throttling import UserRateThrottle
 
 class OTPRequestThrottle(UserRateThrottle):
     scope = "otp_request"
-    rate = "10/hour"
 
 
 class LoginAttemptThrottle(UserRateThrottle):
     scope = "login_attempt"
-    rate = "10/10min"

--- a/skillexa/settings.py
+++ b/skillexa/settings.py
@@ -141,19 +141,21 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 
 REST_FRAMEWORK = {
-    'DEFAULT_AUTHENTICATION_CLASSES': (
+    'DEFAULT_AUTHENTICATION_CLASSES': [
         'rest_framework_simplejwt.authentication.JWTAuthentication',
-    ),
-    'DEFAULT_PERMISSION_CLASSES': (
+    ],
+    'DEFAULT_PERMISSION_CLASSES': [
         'rest_framework.permissions.IsAuthenticated',
-    ),
-    'DEFAULT_THROTTLE_CLASSES': (
-        'rest_framework.throttling.UserRateThrottle',
+    ],
+    'DEFAULT_THROTTLE_CLASSES': [
         'rest_framework.throttling.AnonRateThrottle',
-    ),
-    'DEFAULT_THROTTLE_RATES':{
-        "user": "2000/day",
-        "anon": "200/hour",
+        'rest_framework.throttling.UserRateThrottle'
+    ],
+    'DEFAULT_THROTTLE_RATES': {
+        'anon': '200/day',
+        'user': '2000/day',
+        'otp_request': '5/hour',
+        'login_attempt': '20/hour',
     }
 }
 


### PR DESCRIPTION
This pull request corrects the rate limiting configuration and updates the throttle class definitions.

**Key Changes:**

* **Throttle Class Definitions:**
    * Removed the `rate` attribute from `OTPRequestThrottle` and `LoginAttemptThrottle` classes. These rates are now defined exclusively in `settings.py`.
    * This change centralizes rate limit configurations, making them easier to manage and modify.
* **REST Framework Settings:**
    * Updated `DEFAULT_THROTTLE_CLASSES` to use list syntax `[]` instead of tuple `()`.
    * Reordered the `DEFAULT_THROTTLE_CLASSES` to `AnonRateThrottle` and then `UserRateThrottle`.
    * Updated the `DEFAULT_THROTTLE_RATES` dictionary to include:
        * `otp_request`: '5/hour'
        * `login_attempt`: '20/hour'
        * Reordered the `anon` and `user` keys.
        * Changed `anon` rate from 200/hour to 200/day.
    * This change updates the rate limits to the new desired values.

**Reasoning:**

* Centralizing rate limits in `settings.py` improves maintainability.
* The previous rate limits where to permissive, and have been updated to more secure values.
* The list syntax is more standard for python lists.

**Benefits:**

* Improved maintainability and configuration management.
* Corrected rate limits applied to the application.
* Improved security.

**Testing:**

* Verified that the updated rate limits are correctly applied to the API endpoints.
* Verified that the tests still pass.
* Verified that the api still functions correctly.

**Further Considerations:**

* (Mention any potential future improvements, such as adding more granular rate limits or implementing dynamic rate limiting.)

**Related Issues:**

* (If applicable, reference any related issues, e.g., #123.)

**Labels:**

* bugfix
* refactor
* security
* rate-limiting